### PR TITLE
Added Mac-specific changes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ if (USE_MBEDCRYPTO)
     execute_process(COMMAND patch -p1 -u
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/patched/mbedtls
         INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/mbedtls-ed25519.patch)
+    if(${APPLE})
+        execute_process(COMMAND patch -p1 -u
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/patched/mbedtls
+            INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/mbedtls-apple.patch)
+    endif()
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/patched/mbedtls)
 endif (USE_MBEDCRYPTO)
 

--- a/mbedtls-apple.patch
+++ b/mbedtls-apple.patch
@@ -1,0 +1,12 @@
+diff --git a/library/CMakeLists.txt b/library/CMakeLists.txt
+index a69e73330..aafb454b3 100644
+--- a/library/CMakeLists.txt
++++ b/library/CMakeLists.txt
+@@ -1,3 +1,7 @@
++if(${APPLE})
++	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-but-set-variable -Wno-unused-but-set-parameter")
++endif()
++
+ option(USE_STATIC_MBEDTLS_LIBRARY "Build mbed TLS static library." ON)
+ option(USE_SHARED_MBEDTLS_LIBRARY "Build mbed TLS shared library." OFF)
+ option(LINK_WITH_PTHREAD "Explicitly link mbed TLS library to pthread." OFF)


### PR DESCRIPTION
Made changes to CMakeLists.txt to apply additional patch to mbedtls to allow ignoring errors for unused variables on MacOS when compiling with clang.  Also includes the patch file. 